### PR TITLE
feat: Send notification when no one is on leave

### DIFF
--- a/internal/service/leaveNotifyService.go
+++ b/internal/service/leaveNotifyService.go
@@ -42,6 +42,14 @@ func (e *LeaveNotifyService) HandleEvent() error {
 			log.Printf("Failed to send notification: %v", err)
 			return err
 		}
+} else {
+	message := "No one leave today"
+	log.Printf(message)
+	err = e.notiGateway.Send(message)
+	if err != nil {
+		log.Printf("Failed to send notification: %v", err)
+		return err
+	}
 	}
 
 	return nil

--- a/internal/service/leaveNotifyService_test.go
+++ b/internal/service/leaveNotifyService_test.go
@@ -29,6 +29,12 @@ func (m *MockNotificationGateway) Send(message string) error {
 	return nil
 }
 
+func (m *MockNotificationGateway) AssertSentWithMessage(t *testing.T, expectedMessage string) {
+	if m.sentMessage != expectedMessage {
+		t.Errorf("Expected message to be '%s', but got '%s'", expectedMessage, m.sentMessage)
+	}
+}
+
 func TestEventHandlerWith2Leaves(t *testing.T) {
 	mockNotificationChannel := &MockNotificationGateway{}
 	mockLeaveEventSource := &MockEventRepository{event: []string{"Tum leave", "Songpon leave"}}
@@ -67,9 +73,10 @@ func TestEventHandlerWithNoLeave(t *testing.T) {
 		t.Errorf("Expected no error, but got %v", err)
 	}
 
-	if mockNotificationChannel.numberOfCalls != 0 {
-		t.Errorf("Expected notification channel not to be called, but got %d", mockNotificationChannel.numberOfCalls)
+	if mockNotificationChannel.numberOfCalls != 1 {
+		t.Errorf("Expected notification channel to be called once, but got %d", mockNotificationChannel.numberOfCalls)
 	}
+	mockNotificationChannel.AssertSentWithMessage(t, "No one leave today")
 }
 
 func TestEventHandlerWithLeaveEventSourceError(t *testing.T) {


### PR DESCRIPTION
I've modified the leave notification service to send a message "No one leave today" to the Line group when there are no leave events for the current day.

I also added a unit test to verify that the notification is sent correctly in this scenario.